### PR TITLE
add engines to note node 14 is needed in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "test": "mocha \"test/**/*.ts\"",
     "watch": "tsc -p . --watch"
   },
+  "engines": {
+    "node": ">=14"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"


### PR DESCRIPTION
Hi, it's very useful tool for me and I wonder if it become a little better.

`npx set-env-to-github_env` using node in lower versions than v14 results an error `Cannot find module 'fs/promises'` .  It may be because that the alias had been added since node v14.0.0 [https://nodejs.org/en/blog/release/v14.0.0/#other-notable-changes](https://nodejs.org/en/blog/release/v14.0.0/#other-notable-changes).  

```
$ npx set-env-to-github_env
npx: 78個のパッケージを3.23秒でインストールしました。
Cannot find module 'fs/promises'
Require stack:
- /Users/hogashi/.npm/_npx/76957/lib/node_modules/set-env-to-github_env/lib/cli.js
- /Users/hogashi/.npm/_npx/76957/lib/node_modules/set-env-to-github_env/bin/cmd.js
```

I suggest to add `engines` setting in package.json to notify that the version v14 is required.  With `npx` , `engine` is ignored by default but except if there is `engine-strict=true` in .npmrc.  So the error message would be better if they have .npmrc configured.
