### PR TITLE
ShellCheck warns SC2086 in migrated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A migration tools convert `::set-env` to $GITHUB_ENV on GitHub Actions.
 
 ## Supported Migration
 
-- [x] `echo "::set-env name={name}::{value}"` → `echo "{name}={value}" >> $GITHUB_ENV`
-- [x] `echo "::set-output name={name}::{value}"` → `echo "{name}={value}" >> $GITHUB_OUTPUT`
-- [x] `echo "::set-state name={name}::{value}"` → `echo "{name}={value}" >> $GITHUB_STATE`
+- [x] `echo "::set-env name={name}::{value}"` → `echo "{name}={value}" >> "$GITHUB_ENV"`
+- [x] `echo "::set-output name={name}::{value}"` → `echo "{name}={value}" >> "$GITHUB_OUTPUT"`
+- [x] `echo "::set-state name={name}::{value}"` → `echo "{name}={value}" >> "$GITHUB_STATE"`
 
 For more details, see GitHub blog and documentation.
 
@@ -75,8 +75,8 @@ jobs:
       - name: set env for prod
         if: github.ref == 'refs/heads/main'
         run: |
-          echo "FILE_ID=${FILE_ID}" >> $GITHUB_ENV
-          echo "BUCKET_NAME=${BUCKET_NAME}" >> $GITHUB_ENV
+          echo "FILE_ID=${FILE_ID}" >> "$GITHUB_ENV"
+          echo "BUCKET_NAME=${BUCKET_NAME}" >> "$GITHUB_ENV"
         env:
           FILE_ID: 123456789012
           BUCKET_NAME: deploy-prod

--- a/src/set-env-to-github_env.ts
+++ b/src/set-env-to-github_env.ts
@@ -1,15 +1,15 @@
 export function convert(content: string) {
     const ENV_PATTERN = [
         /echo\s+(["'])?::set-env name=(?<name>\${?.+}?|.+)::(?<variableName>\${?.+}?|.+)\1/g,
-        `echo "$<name>=$<variableName>" >> $GITHUB_ENV`
+        `echo "$<name>=$<variableName>" >> "$GITHUB_ENV"`
     ] as const;
     const SAVE_PATTERN = [
         /echo\s+(["'])?::set-state name=(?<name>\${?.+}?|.+)::(?<variableName>\${?.+}?|.+)\1/g,
-        `echo "$<name>=$<variableName>" >> $GITHUB_STATE`
+        `echo "$<name>=$<variableName>" >> "$GITHUB_STATE"`
     ] as const;
     const OUTPUT_PATTERN = [
         /echo\s+(["'])?::set-output name=(?<name>\${?.+}?|.+)::(?<variableName>\${?.+}?|.+)\1/g,
-        `echo "$<name>=$<variableName>" >> $GITHUB_OUTPUT`
+        `echo "$<name>=$<variableName>" >> "$GITHUB_OUTPUT"`
     ] as const;
     return [ENV_PATTERN, SAVE_PATTERN, OUTPUT_PATTERN].reduce((output, [pattern, replacement]) => {
         return output.replace(pattern, replacement);

--- a/test/snapshots/example-honkit/output.yml
+++ b/test/snapshots/example-honkit/output.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set Current Version
         run: |
           CURRENT_VERSION=$(node -p 'require("./lerna.json").version')
-          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_ENV
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> "$GITHUB_ENV"
       - name: Tag Check
         id: tag_check
         run: |
@@ -42,9 +42,9 @@ jobs:
           http_status_code=$(curl -LI $GET_API_URL -o /dev/null -w '%{http_code}\n' -s \
             -H "Authorization: token ${GITHUB_TOKEN}")
           if [ "$http_status_code" -ne "404" ] ; then
-            echo "exists_tag=true" >> $GITHUB_OUTPUT
+            echo "exists_tag=true" >> "$GITHUB_OUTPUT"
           else
-            echo "exists_tag=false" >> $GITHUB_OUTPUT
+            echo "exists_tag=false" >> "$GITHUB_OUTPUT"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -96,13 +96,13 @@ jobs:
       - name: "Set TAG_NAME=tags"
         if: steps.tag_check.outputs.exists_tag == 'false' && github.event.pull_request.merged == true
         run: |
-          echo "TAG_NAME=v${{ env.CURRENT_VERSION }}" >> $GITHUB_ENV
-          echo "PACKAGE_VERSION=${{ env.CURRENT_VERSION  }}" >> $GITHUB_ENV
+          echo "TAG_NAME=v${{ env.CURRENT_VERSION }}" >> "$GITHUB_ENV"
+          echo "PACKAGE_VERSION=${{ env.CURRENT_VERSION  }}" >> "$GITHUB_ENV"
       - name: Set HUB_TAG
         if: steps.tag_check.outputs.exists_tag == 'false' && github.event.pull_request.merged == true
         run: |
-          echo "HUB_TAG=${DOCKER_HUB_BASE_NAME}:${TAG_NAME}" >> $GITHUB_ENV
-          echo "HUB_LATEST_TAG=${DOCKER_HUB_BASE_NAME}:latest" >> $GITHUB_ENV
+          echo "HUB_TAG=${DOCKER_HUB_BASE_NAME}:${TAG_NAME}" >> "$GITHUB_ENV"
+          echo "HUB_LATEST_TAG=${DOCKER_HUB_BASE_NAME}:latest" >> "$GITHUB_ENV"
       - name: Build image
         if: steps.tag_check.outputs.exists_tag == 'false' && github.event.pull_request.merged == true
         run: |

--- a/test/snapshots/set-env-to-GITHUB_ENV/output.yml
+++ b/test/snapshots/set-env-to-GITHUB_ENV/output.yml
@@ -8,16 +8,16 @@ jobs:
       - name: set env for prod
         if: github.ref == 'refs/heads/main'
         run: |
-          echo "FILE_ID=${FILE_ID}" >> $GITHUB_ENV
-          echo "BUCKET_NAME=${BUCKET_NAME}" >> $GITHUB_ENV
+          echo "FILE_ID=${FILE_ID}" >> "$GITHUB_ENV"
+          echo "BUCKET_NAME=${BUCKET_NAME}" >> "$GITHUB_ENV"
         env:
           FILE_ID: 123456789012
           BUCKET_NAME: deploy-prod
       - name: set env for prod without quote
         if: github.ref == 'refs/heads/main'
         run: |
-          echo "FILE_ID=${FILE_ID}" >> $GITHUB_ENV
-          echo "BUCKET_NAME=${BUCKET_NAME}" >> $GITHUB_ENV
+          echo "FILE_ID=${FILE_ID}" >> "$GITHUB_ENV"
+          echo "BUCKET_NAME=${BUCKET_NAME}" >> "$GITHUB_ENV"
         env:
           FILE_ID: 123456789012
           BUCKET_NAME: deploy-prod

--- a/test/snapshots/set-output-to-GITHUB_OUTPUT/output.yml
+++ b/test/snapshots/set-output-to-GITHUB_OUTPUT/output.yml
@@ -8,10 +8,10 @@ jobs:
       - name: set env for prod
         if: github.ref == 'refs/heads/main'
       - name: Set output
-        run: echo "key=$value" >> $GITHUB_OUTPUT
+        run: echo "key=$value" >> "$GITHUB_OUTPUT"
         env:
           value: "value"
       - name: Set output
-        run: echo "key=value" >> $GITHUB_OUTPUT
+        run: echo "key=value" >> "$GITHUB_OUTPUT"
       - name: Set output
-        run: echo "key=value" >> $GITHUB_OUTPUT
+        run: echo "key=value" >> "$GITHUB_OUTPUT"

--- a/test/snapshots/set-state-to-GITHUB_STATE/output.yml
+++ b/test/snapshots/set-state-to-GITHUB_STATE/output.yml
@@ -8,10 +8,10 @@ jobs:
       - name: set env for prod
         if: github.ref == 'refs/heads/main'
       - name: Set state
-        run: echo "key=$value" >> $GITHUB_STATE
+        run: echo "key=$value" >> "$GITHUB_STATE"
         eng:
           value: "value"
       - name: Set state
-        run: echo "key=value" >> $GITHUB_STATE
+        run: echo "key=value" >> "$GITHUB_STATE"
       - name: Set state
-        run: echo "key=key" >> $GITHUB_STATE
+        run: echo "key=key" >> "$GITHUB_STATE"


### PR DESCRIPTION
ShellCheck warns SC2086 (Double quote to prevent globbing and word splitting) in migrated code.

Problematic code:

```
echo "{name}={value}" >> $GITHUB_OUTPUT
```

Fixed

```
echo "{name}={value}" >> "$GITHUB_OUTPUT"
```

refs https://www.shellcheck.net/wiki/SC2086